### PR TITLE
Rustプログラムの高速化

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,3 +3,12 @@
 [[package]]
 name = "langs-bench-rust"
 version = "0.1.0"
+dependencies = [
+ "rustc-hash",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["reki2000 <reki2000@example.com>"]
 edition = "2018"
 
 [dependencies]
+rustc-hash = "1.1.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,5 +2,6 @@
 name = "langs-bench-rust"
 version = "0.1.0"
 authors = ["reki2000 <reki2000@example.com>"]
+edition = "2018"
 
 [dependencies]

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,8 +1,9 @@
 all: main
 
 clean:
-	rm main
-	rm -rf target
+	cargo clean
+	rm -f main
 
 main: src/main.rs
-	rustc -C opt-level=3 src/main.rs
+	cargo build --release
+	cp -p ./target/release/langs-bench-rust ./main

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -32,7 +32,7 @@ fn get_idx(g: &mut G, id: NodeId) -> NodeIndex {
     g.idx2id.push(id);
     g.edge.push(vec![]);
     g.idx += 1;
-    return i;
+    i
 }
 
 fn add_edge(g: &mut G, start: NodeId, end: NodeId, distance: Distance) {
@@ -55,7 +55,7 @@ fn stof100(s: &str) -> u32 {
         result *= 10;
         result += (ch as u32) - ('0' as u32);
         if place > 0 {
-            place = place + 1;
+            place += 1;
             if place >= 3 {
                 break;
             }
@@ -65,7 +65,7 @@ fn stof100(s: &str) -> u32 {
         result *= 10;
         place += 1;
     }
-    return result;
+    result
 }
 
 fn load(g: &mut G) {
@@ -88,6 +88,9 @@ fn load(g: &mut G) {
     }
 }
 
+// Disable Clippy warning for a lint: more than 4 bindings with single-character names in a scope.
+// https://rust-lang.github.io/rust-clippy/master/index.html#many_single_char_names
+#[allow(clippy::many_single_char_names)]
 fn dijkstra(g: &G, start: NodeId, end: NodeId) -> (Distance, Vec<NodeId>) {
     let s = *g.id2idx.get(&start).unwrap();
     let e = *g.id2idx.get(&end).unwrap();
@@ -109,7 +112,7 @@ fn dijkstra(g: &G, start: NodeId, end: NodeId) -> (Distance, Vec<NodeId>) {
                 println!("visiting: {} distance: {}", here, distance);
             }
         }
-        visited = visited + 1;
+        visited += 1;
         //println!("visiting: {} distance: {} qlen:{} visited:{} avg:{}, max:{}", here, distance, queue.len(), visited, sum/n, max);
         // std::thread::sleep(std::time::Duration::from_millis(1000));
         for edge in &g.edge[here as usize] {
@@ -134,7 +137,7 @@ fn dijkstra(g: &G, start: NodeId, end: NodeId) -> (Distance, Vec<NodeId>) {
         result.push(g.idx2id[n as usize]);
     }
 
-    return ((d[e as usize] / DISTANCE_MULTIPLE) as Distance, result);
+    ((d[e as usize] / DISTANCE_MULTIPLE) as Distance, result)
 }
 
 static mut IS_DEBUG: bool = false;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,9 +1,10 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
-use std::collections::HashMap;
 use std::env;
 use std::io;
 use std::io::prelude::*;
+
+use rustc_hash::FxHashMap;
 
 type NodeId = u32;
 type NodeIndex = u32;
@@ -17,7 +18,7 @@ struct Edge {
 }
 
 struct G {
-    id2idx: HashMap<NodeId, NodeIndex>,
+    id2idx: FxHashMap<NodeId, NodeIndex>,
     idx2id: Vec<NodeId>,
     idx: NodeIndex,
     edge: Vec<Vec<Edge>>,
@@ -150,7 +151,7 @@ fn main() {
     }
 
     let mut g = G {
-        id2idx: HashMap::new(),
+        id2idx: FxHashMap::default(),
         idx2id: vec![0],
         idx: 1,
         edge: vec![vec![]],

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,6 +1,7 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::env;
+use std::error::Error;
 use std::io;
 use std::io::prelude::*;
 
@@ -46,8 +47,8 @@ fn add_edge(g: &mut G, start: NodeId, end: NodeId, distance: Distance) {
 }
 
 fn stof100(s: &str) -> u32 {
-    let mut result: u32 = 0;
-    let mut place: u32 = 0;
+    let mut result = 0;
+    let mut place = 0u32;
     for ch in s.chars() {
         if ch == '.' {
             place = 1;
@@ -69,22 +70,22 @@ fn stof100(s: &str) -> u32 {
     result
 }
 
-fn load(g: &mut G) {
+fn load(g: &mut G) -> Result<(), Box<dyn Error>> {
     for line in io::stdin().lock().lines().skip(1) {
-        if let Ok(l) = line {
-            let mut fields = l.split(',').skip(2);
-            let s: u32 = fields.next().unwrap().parse().unwrap();
-            let e: u32 = fields.next().unwrap().parse().unwrap();
-            fields.next().unwrap();
-            let d = stof100(fields.next().unwrap());
-            unsafe {
-                if IS_DEBUG {
-                    println!("line: {} s: {} e: {} D: {}", l, s, e, d);
-                }
+        let line = line?;
+        let mut fields = line.split(',').skip(2);
+        let s: u32 = fields.next().unwrap().parse()?;
+        let e: u32 = fields.next().unwrap().parse()?;
+        fields.next().unwrap();
+        let d = stof100(fields.next().unwrap());
+        unsafe {
+            if IS_DEBUG {
+                println!("line: {} s: {} e: {} D: {}", line, s, e, d);
             }
-            add_edge(g, s, e, d as Distance);
         }
+        add_edge(g, s, e, d as Distance);
     }
+    Ok(())
 }
 
 // Disable Clippy warning for a lint: more than 4 bindings with single-character names in a scope.
@@ -141,9 +142,9 @@ fn dijkstra(g: &G, start: NodeId, end: NodeId) -> (Distance, Vec<NodeId>) {
 
 static mut IS_DEBUG: bool = false;
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
-    let count: i32 = args[1].parse().unwrap();
+    let count: i32 = args[1].parse()?;
     unsafe {
         IS_DEBUG = args.len() > 2 && args[2] == "debug";
     }
@@ -155,7 +156,7 @@ fn main() {
         edge: vec![vec![]],
     };
 
-    load(&mut g);
+    load(&mut g)?;
     println!("loaded nodes: {}", g.idx);
 
     let mut distance: Distance;
@@ -173,4 +174,5 @@ fn main() {
         result = result + &id.to_string() + " ";
     }
     println!("{}", result);
+    Ok(())
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,167 +1,174 @@
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::collections::HashMap;
 use std::env;
 use std::io;
 use std::io::prelude::*;
-use std::collections::HashMap;
-use std::collections::BinaryHeap;
-use std::cmp::Reverse;
 
 type NodeId = u32;
 type NodeIndex = u32;
 type Distance = u32;
 
-const DISTANCE_MULTIPLE:u32 = 100;
+const DISTANCE_MULTIPLE: u32 = 100;
 
 struct Edge {
-	first: NodeIndex,
-	second: Distance,
+    first: NodeIndex,
+    second: Distance,
 }
 
 struct G {
-	id2idx: HashMap<NodeId,NodeIndex>,
-	idx2id: Vec<NodeId>,
-	idx:    NodeIndex,
-	edge:   Vec<Vec<Edge>>,
+    id2idx: HashMap<NodeId, NodeIndex>,
+    idx2id: Vec<NodeId>,
+    idx: NodeIndex,
+    edge: Vec<Vec<Edge>>,
 }
 
-fn get_idx(g:&mut G, id:NodeId) -> NodeIndex {
-	if let Some(i) = g.id2idx.get(&id) {
-		return *i;
-	}
-	let i = g.idx;
-	g.id2idx.insert(id, i);
-	g.idx2id.push(id);
-	g.edge.push(vec![]);
-	g.idx += 1;
-	return i;
+fn get_idx(g: &mut G, id: NodeId) -> NodeIndex {
+    if let Some(i) = g.id2idx.get(&id) {
+        return *i;
+    }
+    let i = g.idx;
+    g.id2idx.insert(id, i);
+    g.idx2id.push(id);
+    g.edge.push(vec![]);
+    g.idx += 1;
+    return i;
 }
 
-fn add_edge(g:&mut G, start:NodeId, end:NodeId, distance:Distance) {
-	let s = get_idx(g, start);
-	let e = get_idx(g, end);
-	g.edge[(s as usize)].push(Edge{first:e, second:distance});
-
+fn add_edge(g: &mut G, start: NodeId, end: NodeId, distance: Distance) {
+    let s = get_idx(g, start);
+    let e = get_idx(g, end);
+    g.edge[(s as usize)].push(Edge {
+        first: e,
+        second: distance,
+    });
 }
 
-fn stof100(s:&str) -> u32 {
-	let mut result:u32 = 0;
-	let mut place:u32 = 0;
-	for ch in s.chars() {
-		if ch == '.' {
-			place = 1;
-			continue;
-		}
-		result *= 10;
-		result += (ch as u32) - ('0' as u32);
-		if place > 0 {
-			place = place + 1;
-			if place >= 3 {
-				break;
-			}
-		}
-	}
-	while place < 3 {
-		result *= 10;
-		place += 1;
-	}
-	return result;
+fn stof100(s: &str) -> u32 {
+    let mut result: u32 = 0;
+    let mut place: u32 = 0;
+    for ch in s.chars() {
+        if ch == '.' {
+            place = 1;
+            continue;
+        }
+        result *= 10;
+        result += (ch as u32) - ('0' as u32);
+        if place > 0 {
+            place = place + 1;
+            if place >= 3 {
+                break;
+            }
+        }
+    }
+    while place < 3 {
+        result *= 10;
+        place += 1;
+    }
+    return result;
 }
 
-fn load(g:&mut G) {
-	for (index, line) in io::stdin().lock().lines().enumerate() {
-		if index == 0 {
-			continue;
-		}
-		if let Ok(l) = line {
-			let fields: Vec<&str> = l.split(',').collect();
-			let s: u32 = fields[2].parse().unwrap();
-			let e: u32 = fields[3].parse().unwrap();
-			let d: u32 = stof100(fields[5]);
-			unsafe {
-				if IS_DEBUG {
-					println!("line: {} s: {} e: {} D: {}", l, s, e, d);
-				}
-			}
-			add_edge(g, s, e, d as Distance);
-		}
-	}	
+fn load(g: &mut G) {
+    for (index, line) in io::stdin().lock().lines().enumerate() {
+        if index == 0 {
+            continue;
+        }
+        if let Ok(l) = line {
+            let fields: Vec<&str> = l.split(',').collect();
+            let s: u32 = fields[2].parse().unwrap();
+            let e: u32 = fields[3].parse().unwrap();
+            let d: u32 = stof100(fields[5]);
+            unsafe {
+                if IS_DEBUG {
+                    println!("line: {} s: {} e: {} D: {}", l, s, e, d);
+                }
+            }
+            add_edge(g, s, e, d as Distance);
+        }
+    }
 }
 
-fn dijkstra(g:&G, start:NodeId, end:NodeId) -> (Distance, Vec<NodeId>) {
-	let s = *g.id2idx.get(&start).unwrap();
-	let e = *g.id2idx.get(&end).unwrap();
+fn dijkstra(g: &G, start: NodeId, end: NodeId) -> (Distance, Vec<NodeId>) {
+    let s = *g.id2idx.get(&start).unwrap();
+    let e = *g.id2idx.get(&end).unwrap();
 
-	let size = g.idx as usize;
-	let mut d = vec![0 as Distance; size];
-	let mut prev = vec![0 as NodeIndex; size];
+    let size = g.idx as usize;
+    let mut d = vec![0 as Distance; size];
+    let mut prev = vec![0 as NodeIndex; size];
 
-	//let mut vv = vec![0; size];
+    //let mut vv = vec![0; size];
 
-	let mut queue = BinaryHeap::new();
-	queue.push((Reverse(0), Reverse(s)));
+    let mut queue = BinaryHeap::new();
+    queue.push((Reverse(0), Reverse(s)));
 
-	let mut visited = 0;
-	while let Some(v) = queue.pop() {
-		let (Reverse(distance), Reverse(here)) = (v.0, v.1);
-		unsafe {
-			if IS_DEBUG {
-				println!("visiting: {} distance: {}", here, distance);
-			}
-		}
-		visited = visited + 1;
-		//println!("visiting: {} distance: {} qlen:{} visited:{} avg:{}, max:{}", here, distance, queue.len(), visited, sum/n, max);
-		// std::thread::sleep(std::time::Duration::from_millis(1000));
-		for edge in &g.edge[here as usize] {
-			let (to, weight) = (edge.first as usize, edge.second);
-			let w = distance + weight;
-			// println!("visiting:{} distance:{} to:{}, d[to]:{}, w:{}, qlen:{} visited:{}", here, distance, to, d[to], w, queue.len(), visited);
-			if d[to] == 0 || w < d[to] {
-				prev[to] = here;
-				d[to] = w;
-				// vv[to] = vv[to] + 1;
-				queue.push((Reverse(w), Reverse(to as NodeIndex)));
-			}
-		}
-	}
-	println!("visited: {}", visited);
+    let mut visited = 0;
+    while let Some(v) = queue.pop() {
+        let (Reverse(distance), Reverse(here)) = (v.0, v.1);
+        unsafe {
+            if IS_DEBUG {
+                println!("visiting: {} distance: {}", here, distance);
+            }
+        }
+        visited = visited + 1;
+        //println!("visiting: {} distance: {} qlen:{} visited:{} avg:{}, max:{}", here, distance, queue.len(), visited, sum/n, max);
+        // std::thread::sleep(std::time::Duration::from_millis(1000));
+        for edge in &g.edge[here as usize] {
+            let (to, weight) = (edge.first as usize, edge.second);
+            let w = distance + weight;
+            // println!("visiting:{} distance:{} to:{}, d[to]:{}, w:{}, qlen:{} visited:{}", here, distance, to, d[to], w, queue.len(), visited);
+            if d[to] == 0 || w < d[to] {
+                prev[to] = here;
+                d[to] = w;
+                // vv[to] = vv[to] + 1;
+                queue.push((Reverse(w), Reverse(to as NodeIndex)));
+            }
+        }
+    }
+    println!("visited: {}", visited);
 
-	let mut n = e;
-	let mut result = vec![g.idx2id[n as usize]];
+    let mut n = e;
+    let mut result = vec![g.idx2id[n as usize]];
 
-	while d[n as usize] != 0 && n != s && n != 0 {
-		n = prev[n as usize];
-		result.push(g.idx2id[n as usize]);
-	}
+    while d[n as usize] != 0 && n != s && n != 0 {
+        n = prev[n as usize];
+        result.push(g.idx2id[n as usize]);
+    }
 
-	return ((d[e as usize] / DISTANCE_MULTIPLE) as Distance, result);
+    return ((d[e as usize] / DISTANCE_MULTIPLE) as Distance, result);
 }
 
 static mut IS_DEBUG: bool = false;
 
 fn main() {
-	let args: Vec<String> = env::args().collect();
-	let count: i32 = args[1].parse().unwrap();
-	unsafe {
-		IS_DEBUG = args.len() > 2 && args[2] == "debug";
-	}
+    let args: Vec<String> = env::args().collect();
+    let count: i32 = args[1].parse().unwrap();
+    unsafe {
+        IS_DEBUG = args.len() > 2 && args[2] == "debug";
+    }
 
-	let mut g = G{id2idx:HashMap::new(), idx2id:vec![0], idx:1, edge:vec![vec![]]};
+    let mut g = G {
+        id2idx: HashMap::new(),
+        idx2id: vec![0],
+        idx: 1,
+        edge: vec![vec![]],
+    };
 
-	load(&mut g);
-	println!("loaded nodes: {}", g.idx);
+    load(&mut g);
+    println!("loaded nodes: {}", g.idx);
 
-	let mut distance: Distance;
-	let mut route = vec![0 as NodeId; 0];
-	for i in 0..count {
-		let s = g.idx2id[((i+1)*1000) as usize];
-		let result = dijkstra(&g, s, g.idx2id[1]);
-		distance = result.0;
-		route = result.1;
-		println!("distance: {}", distance);
-	}
+    let mut distance: Distance;
+    let mut route = vec![0 as NodeId; 0];
+    for i in 0..count {
+        let s = g.idx2id[((i + 1) * 1000) as usize];
+        let result = dijkstra(&g, s, g.idx2id[1]);
+        distance = result.0;
+        route = result.1;
+        println!("distance: {}", distance);
+    }
 
-	let mut result = String::from("route: ");
-	for id in route {
-		result = result + &id.to_string() + " ";
-	}
-	println!("{}", result);
+    let mut result = String::from("route: ");
+    for id in route {
+        result = result + &id.to_string() + " ";
+    }
+    println!("{}", result);
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -70,15 +70,13 @@ fn stof100(s: &str) -> u32 {
 }
 
 fn load(g: &mut G) {
-    for (index, line) in io::stdin().lock().lines().enumerate() {
-        if index == 0 {
-            continue;
-        }
+    for line in io::stdin().lock().lines().skip(1) {
         if let Ok(l) = line {
-            let fields: Vec<&str> = l.split(',').collect();
-            let s: u32 = fields[2].parse().unwrap();
-            let e: u32 = fields[3].parse().unwrap();
-            let d: u32 = stof100(fields[5]);
+            let mut fields = l.split(',').skip(2);
+            let s: u32 = fields.next().unwrap().parse().unwrap();
+            let e: u32 = fields.next().unwrap().parse().unwrap();
+            fields.next().unwrap();
+            let d = stof100(fields.next().unwrap());
             unsafe {
                 if IS_DEBUG {
                     println!("line: {} s: {} e: {} D: {}", l, s, e, d);


### PR DESCRIPTION
Rustについてですが、少し高速化できそうでしたので試してみました。

1. `HashMap`のハッシュ関数を高速なものに変更
2. CSVの各行をパースする際に一時的な`Vec`の作成を避ける
3. その他
   - コードフォーマッタ（`cargo fmt`）の適用
   - Lintツール（`cargo clippy`）の指摘内容の修正
   - `?`演算子を使った簡単なエラー処理

1と2について詳しくは、Qiitaの記事の [コメント](https://qiita.com/reki2000/items/55ef54b96b26d80ad694#comment-1183bf5d90ac6ac98e3d) を参照してください。

一応、修正内容ごとにコミットを分けていますので、個々のコミットを見ていただくと内容がわかりやすいと思います。

## 結果

1回ずつしか計測していませんが、以下のような結果になりました。

| 内容 | 所要時間（秒）| 高速化の度合い |
|:----|----:|----:|
| 元のプログラム | 2.192 | |
| ハッシュ関数の変更 | 2.103 | ~4% |
| `Vec`の作成を避ける | 1.836 | ~19% |

**環境**

- Linux x86_64 (Fedora 32)
- CPU: Intel(R) Core(TM) i5-7200U CPU @ 2.50GHz
