### PR TITLE
C++版のリファクタリング/高速化

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ And runs on languages below:
 - JavaScript : NodeJS 13 
 - Kotlin : 1.3 + jdk >=8
 - Julia : 1.4
-- GCC : 7.5 (or versions which support C++17)
+- Clang : 7 (or versions which support C++17)
 
 I like to use [asdf](https://asdf-vm.com/#/) to set up those environments.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ And runs on languages below:
 - JavaScript : NodeJS 13 
 - Kotlin : 1.3 + jdk >=8
 - Julia : 1.4
-- GCC : 7.5 (or versions which support C++11)
+- GCC : 7.5 (or versions which support C++17)
 
 I like to use [asdf](https://asdf-vm.com/#/) to set up those environments.
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -4,4 +4,4 @@ clean:
 	rm main
 
 main: src/main.cpp
-	g++ -std=gnu++11 -O3 -Wall -Wextra -march=native -mtune=native -o main src/main.cpp
+	g++ -std=c++17 -O3 -Wall -Wextra -pedantic-errors -march=native -mtune=native -o main src/main.cpp

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -4,4 +4,4 @@ clean:
 	rm main
 
 main: src/main.cpp
-	g++ -std=gnu++11 -O3 -o main src/main.cpp
+	g++ -std=gnu++11 -O3 -Wall -Wextra -march=native -mtune=native -o main src/main.cpp

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -4,4 +4,4 @@ clean:
 	rm main
 
 main: src/main.cpp
-	g++ -std=c++17 -O3 -Wall -Wextra -pedantic-errors -march=native -mtune=native -o main src/main.cpp
+	clang++ -std=c++17 -O3 -Wall -Wextra -pedantic-errors -march=native -mtune=native -o main src/main.cpp

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -9,7 +9,7 @@ using NodeIndex = int;
 using Distance = int;
 using Edge = std::pair<NodeIndex, Distance>;
 
-const int DISTANCE_MULTIPLE = 100;
+constexpr int DISTANCE_MULTIPLE = 100;
 
 bool is_debug = false;
 

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -1,5 +1,5 @@
 #include<vector>
-#include<map>
+#include<unordered_map>
 #include<string>
 #include<iostream>
 #include<queue>
@@ -14,7 +14,7 @@ const int DISTANCE_MULTIPLE = 100;
 bool is_debug = false;
 
 struct G {
-  std::map<NodeId,NodeIndex> id2idx;
+  std::unordered_map<NodeId,NodeIndex> id2idx;
   std::vector<NodeId> idx2id = {0};
   NodeIndex idx = 1;
   std::vector<std::vector<Edge>> edge = {std::vector<Edge>()};

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -35,7 +35,7 @@ inline NodeIndex get_idx(NodeId id) {
 inline void add_edge(NodeId start, NodeId end, Distance distance) {
   const NodeIndex s = get_idx(start);
   const NodeIndex e = get_idx(end);
-  g.edge[s].push_back({e, distance});
+  g.edge[s].emplace_back(e, distance);
 }
 
 inline int stoi(std::string_view s) {

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -1,4 +1,9 @@
-#include <bits/stdc++.h>
+#include<vector>
+#include<map>
+#include<string>
+#include<iostream>
+#include<queue>
+
 using namespace std;
 
 using NodeId = int;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -96,8 +96,8 @@ pair<Distance, vector<NodeId>> dijkstra(NodeId start, NodeId end) {
   NodeIndex e = get_idx(end);
 
   int size = g.idx;
-  Distance d[size] = {};
-  NodeIndex prev[size] = {};
+  std::vector<Distance> d(size);
+  std::vector<NodeIndex> prev(size);
 
   priority_queue<Visit, vector<Visit>, greater<Visit>> queue;
   queue.push({0,s});

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -1,6 +1,7 @@
 #include<vector>
 #include<unordered_map>
 #include<string>
+#include<string_view>
 #include<iostream>
 #include<queue>
 
@@ -144,7 +145,7 @@ int main(int argc, char **argv) {
   std::cin.tie(nullptr);
 
   const int count = atoi(argv[1]);
-  is_debug = argc > 2 && std::string(argv[2]) == "debug";
+  is_debug = argc > 2 && std::string_view(argv[2]) == "debug";
 
   load();
   std::cerr << "loaded nodes: " << g.idx << std::endl;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -82,8 +82,8 @@ void load() {
     }
     NodeId s = 0, e = 0;
     Distance d = 0;
-    for (int idx=0, pos=0, prev_pos=0; static_cast<std::string::size_type>(pos) <= line.length(); pos++) {
-      if (line[pos] == ',' || static_cast<std::string::size_type>(pos) == line.length()) {
+    for (std::string::size_type idx=0, pos=0, prev_pos=0; pos <= line.length(); pos++) {
+      if (line[pos] == ',' || pos == line.length()) {
         const auto field = std::string_view{line}.substr(prev_pos, pos-prev_pos);
         switch (idx) {
           case 2: s = stoi_unchecked(field); break;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -65,10 +65,10 @@ int stof100(const char *s) {
 
 void load() {
   std::string line;
-  std::cin >> line; // skip header
+  std::getline(std::cin, line); // skip header
 
   while (true) {
-    std::cin >> line;
+    std::getline(std::cin, line);
     if (std::cin.eof()) {
       break;
     }

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -39,26 +39,25 @@ void add_edge(NodeId start, NodeId end, Distance distance) {
 }
 
 // 123.4567 --> 12345
-int stof100(const char *s) {
+int stof100(std::string_view s) {
   int result = 0;
-  int place = 0;
-  for (;*s != '\0'; s++) {
-    if (*s == '.') {
-      place = 1;
-      continue;
+  int place = 3;
+  auto it = s.cbegin();
+  const auto end = s.cend();
+  for(; it != end; ++it) {
+    if (*it == '.') {
+      ++it;
+      break;
     }
     result *= 10;
-    result += *s - '0';
-    if (place > 0) {
-      place++;
-      if (place >= 3) {
-          break;
-      }
-    }
+    result += *it - '0';
   }
-  while (place < 3) {
+  for(; it != end && place --> 0; ++it) {
     result *= 10;
-    place++;
+    result += *it - '0';
+  }
+  while(place --> 0) {
+    result *= 10;
   }
   return result;
 }
@@ -80,7 +79,7 @@ void load() {
         switch (idx) {
           case 2: s = stoi(field); break;
           case 3: e = stoi(field); break;
-          case 5: d = stof100(field.c_str()); break;
+          case 5: d = stof100(field); break;
         }
         prev_pos = pos+1;
         idx++;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -38,7 +38,7 @@ inline void add_edge(NodeId start, NodeId end, Distance distance) {
   g.edge[s].emplace_back(e, distance);
 }
 
-inline int stoi(std::string_view s) {
+inline int stoi_unchecked(std::string_view s) {
   int result = 0;
   for(auto&& x : s) {
     result *= 10;
@@ -86,8 +86,8 @@ void load() {
       if (line[pos] == ',' || static_cast<std::string::size_type>(pos) == line.length()) {
         const auto field = std::string_view{line}.substr(prev_pos, pos-prev_pos);
         switch (idx) {
-          case 2: s = stoi(field); break;
-          case 3: e = stoi(field); break;
+          case 2: s = stoi_unchecked(field); break;
+          case 3: e = stoi_unchecked(field); break;
           case 5: d = stof100(field); break;
         }
         prev_pos = pos+1;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -32,8 +32,8 @@ NodeIndex get_idx(NodeId id) {
 }
 
 void add_edge(NodeId start, NodeId end, Distance distance) {
-  NodeIndex s = get_idx(start);
-  NodeIndex e = get_idx(end);
+  const NodeIndex s = get_idx(start);
+  const NodeIndex e = get_idx(end);
   g.edge[s].push_back({e, distance});
 }
 
@@ -75,7 +75,7 @@ void load() {
     float d = 0;
     for (int idx=0, pos=0, prev_pos=0; pos <= line.length(); pos++) {
       if (line[pos] == ',' || pos == line.length()) {
-        auto field = line.substr(prev_pos, pos-prev_pos);
+        const auto field = line.substr(prev_pos, pos-prev_pos);
         switch (idx) {
           case 2: s = stoi(field); break;
           case 3: e = stoi(field); break;
@@ -95,10 +95,10 @@ void load() {
 using Visit = std::pair<Distance, NodeIndex>;
 
 std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId end) {
-  NodeIndex s = get_idx(start);
-  NodeIndex e = get_idx(end);
+  const NodeIndex s = get_idx(start);
+  const NodeIndex e = get_idx(end);
 
-  int size = g.idx;
+  const int size = g.idx;
   std::vector<Distance> d(size);
   std::vector<NodeIndex> prev(size);
 
@@ -107,15 +107,15 @@ std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId end) {
 
   int visited = 0;
   while (!queue.empty()) {
-    auto a = queue.top();
+    const auto a = queue.top();
     queue.pop();
-    Distance distance = a.first;
-    NodeIndex here = a.second;
+    const Distance distance = a.first;
+    const NodeIndex here = a.second;
     if (is_debug) std::cout << "visiting: " << here << " distance: " << distance << std::endl;
     visited++;
-    for (Edge e : g.edge[here]) {
-      NodeIndex to = e.first;
-      Distance w = distance + e.second;
+    for (const Edge& e : g.edge[here]) {
+      const NodeIndex to = e.first;
+      const Distance w = distance + e.second;
       if (d[to] == 0 || w < d[to]) {
         prev[to] = here;
         d[to] = w;
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
   std::ios::sync_with_stdio(false);
   std::cin.tie(nullptr);
 
-  int count = atoi(argv[1]);
+  const int count = atoi(argv[1]);
   is_debug = argc > 2 && std::string(argv[2]) == "debug";
 
   load();
@@ -151,13 +151,13 @@ int main(int argc, char **argv) {
 
   std::pair<Distance, std::vector<NodeId>> result;
   for (int i=0; i<count; i++) {
-    NodeId s = g.idx2id[(i+1) * 1000];
+    const NodeId s = g.idx2id[(i+1) * 1000];
     result = dijkstra(s, g.idx2id[1]);
     std::cout << "distance: " << result.first << std::endl;
   }
 
   std::cout << "route: ";
-  for (NodeId id: result.second) {
+  for (const NodeId id: result.second) {
     std::cout << id << " ";
   }
   std::cout << std::endl;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -21,7 +21,7 @@ struct G {
   std::vector<std::vector<Edge>> edge = {std::vector<Edge>()};
 } g;
 
-NodeIndex get_idx(NodeId id) {
+inline NodeIndex get_idx(NodeId id) {
   NodeIndex i = g.id2idx[id];
   if (i == 0) {
     i = g.idx++;
@@ -32,13 +32,13 @@ NodeIndex get_idx(NodeId id) {
   return i;
 }
 
-void add_edge(NodeId start, NodeId end, Distance distance) {
+inline void add_edge(NodeId start, NodeId end, Distance distance) {
   const NodeIndex s = get_idx(start);
   const NodeIndex e = get_idx(end);
   g.edge[s].push_back({e, distance});
 }
 
-int stoi(std::string_view s) {
+inline int stoi(std::string_view s) {
   int result = 0;
   for(auto&& x : s) {
     result *= 10;
@@ -48,7 +48,7 @@ int stoi(std::string_view s) {
 }
 
 // 123.4567 --> 12345
-int stof100(std::string_view s) {
+inline int stof100(std::string_view s) {
   int result = 0;
   int place = 3;
   auto it = s.cbegin();
@@ -103,7 +103,7 @@ void load() {
 
 using Visit = std::pair<Distance, NodeIndex>;
 
-std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId end) {
+inline std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId end) {
   const NodeIndex s = get_idx(start);
   const NodeIndex e = get_idx(end);
 

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -73,8 +73,8 @@ void load() {
     }
     int s = 0, e = 0;
     float d = 0;
-    for (int idx=0, pos=0, prev_pos=0; pos <= line.length(); pos++) {
-      if (line[pos] == ',' || pos == line.length()) {
+    for (int idx=0, pos=0, prev_pos=0; static_cast<std::string::size_type>(pos) <= line.length(); pos++) {
+      if (line[pos] == ',' || static_cast<std::string::size_type>(pos) == line.length()) {
         const auto field = line.substr(prev_pos, pos-prev_pos);
         switch (idx) {
           case 2: s = stoi(field); break;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -38,6 +38,15 @@ void add_edge(NodeId start, NodeId end, Distance distance) {
   g.edge[s].push_back({e, distance});
 }
 
+int stoi(std::string_view s) {
+  int result = 0;
+  for(auto&& x : s) {
+    result *= 10;
+    result += x - '0';
+  }
+  return result;
+}
+
 // 123.4567 --> 12345
 int stof100(std::string_view s) {
   int result = 0;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -84,7 +84,7 @@ void load() {
     Distance d = 0;
     for (int idx=0, pos=0, prev_pos=0; static_cast<std::string::size_type>(pos) <= line.length(); pos++) {
       if (line[pos] == ',' || static_cast<std::string::size_type>(pos) == line.length()) {
-        const auto field = line.substr(prev_pos, pos-prev_pos);
+        const auto field = std::string_view{line}.substr(prev_pos, pos-prev_pos);
         switch (idx) {
           case 2: s = stoi(field); break;
           case 3: e = stoi(field); break;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -4,22 +4,20 @@
 #include<iostream>
 #include<queue>
 
-using namespace std;
-
 using NodeId = int;
 using NodeIndex = int;
 using Distance = int;
-using Edge = pair<NodeIndex, Distance>;
+using Edge = std::pair<NodeIndex, Distance>;
 
 const int DISTANCE_MULTIPLE = 100;
 
 bool is_debug = false;
 
 struct G {
-  map<NodeId,NodeIndex> id2idx;
-  vector<NodeId> idx2id = {0};
+  std::map<NodeId,NodeIndex> id2idx;
+  std::vector<NodeId> idx2id = {0};
   NodeIndex idx = 1;
-  vector<vector<Edge>> edge = {vector<Edge>()};
+  std::vector<std::vector<Edge>> edge = {std::vector<Edge>()};
 } g;
 
 NodeIndex get_idx(NodeId id) {
@@ -28,7 +26,7 @@ NodeIndex get_idx(NodeId id) {
     i = g.idx++;
     g.id2idx[id] = i;
     g.idx2id.push_back(id);
-    g.edge.push_back(vector<Edge>());
+    g.edge.push_back(std::vector<Edge>());
   }
   return i;
 }
@@ -65,12 +63,12 @@ int stof100(const char *s) {
 }
 
 void load() {
-  string line;
-  cin >> line; // skip header
+  std::string line;
+  std::cin >> line; // skip header
 
   while (true) {
-    cin >> line;
-    if (cin.eof()) {
+    std::cin >> line;
+    if (std::cin.eof()) {
       break;
     }
     int s = 0, e = 0;
@@ -87,16 +85,16 @@ void load() {
         idx++;
       }
     }
-    if (is_debug) cout << "line: " << line << " s: " << s << " e: " << e << " D: " << d << endl;
+    if (is_debug) std::cout << "line: " << line << " s: " << s << " e: " << e << " D: " << d << std::endl;
     // cerr << "line:" << line << "s:" << s << " e:" << e << " d:" << d << endl;
     // std::this_thread::sleep_for(std::chrono::seconds(1));
     add_edge(s, e, (int)d);
   }
 }
 
-using Visit = pair<Distance, NodeIndex>;
+using Visit = std::pair<Distance, NodeIndex>;
 
-pair<Distance, vector<NodeId>> dijkstra(NodeId start, NodeId end) {
+std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId end) {
   NodeIndex s = get_idx(start);
   NodeIndex e = get_idx(end);
 
@@ -104,7 +102,7 @@ pair<Distance, vector<NodeId>> dijkstra(NodeId start, NodeId end) {
   std::vector<Distance> d(size);
   std::vector<NodeIndex> prev(size);
 
-  priority_queue<Visit, vector<Visit>, greater<Visit>> queue;
+  std::priority_queue<Visit, std::vector<Visit>, std::greater<Visit>> queue;
   queue.push({0,s});
 
   int visited = 0;
@@ -113,7 +111,7 @@ pair<Distance, vector<NodeId>> dijkstra(NodeId start, NodeId end) {
     queue.pop();
     Distance distance = a.first;
     NodeIndex here = a.second;
-    if (is_debug) cout << "visiting: " << here << " distance: " << distance << endl;
+    if (is_debug) std::cout << "visiting: " << here << " distance: " << distance << std::endl;
     visited++;
     for (Edge e : g.edge[here]) {
       NodeIndex to = e.first;
@@ -126,9 +124,9 @@ pair<Distance, vector<NodeId>> dijkstra(NodeId start, NodeId end) {
     }
   }
 
-  cerr << "visited: " << visited << endl;
+  std::cerr << "visited: " << visited << std::endl;
 
-  vector<NodeId> result;
+  std::vector<NodeId> result;
   NodeIndex n = e;
   result.push_back(g.idx2id[n]);
 
@@ -142,25 +140,25 @@ pair<Distance, vector<NodeId>> dijkstra(NodeId start, NodeId end) {
 }
 
 int main(int argc, char **argv) {
-  ios::sync_with_stdio(false);
-  cin.tie(nullptr);
+  std::ios::sync_with_stdio(false);
+  std::cin.tie(nullptr);
 
   int count = atoi(argv[1]);
-  is_debug = argc > 2 && string(argv[2]) == "debug";
+  is_debug = argc > 2 && std::string(argv[2]) == "debug";
 
   load();
-  cerr << "loaded nodes: " << g.idx << endl;
+  std::cerr << "loaded nodes: " << g.idx << std::endl;
 
-  pair<Distance, vector<NodeId>> result;
+  std::pair<Distance, std::vector<NodeId>> result;
   for (int i=0; i<count; i++) {
     NodeId s = g.idx2id[(i+1) * 1000];
     result = dijkstra(s, g.idx2id[1]);
-    cout << "distance: " << result.first << endl;
+    std::cout << "distance: " << result.first << std::endl;
   }
 
-  cout << "route: ";
+  std::cout << "route: ";
   for (NodeId id: result.second) {
-    cout << id << " ";
+    std::cout << id << " ";
   }
-  cout << endl;
+  std::cout << std::endl;
 }

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -80,8 +80,8 @@ void load() {
     if (std::cin.eof()) {
       break;
     }
-    int s = 0, e = 0;
-    float d = 0;
+    NodeId s = 0, e = 0;
+    Distance d = 0;
     for (int idx=0, pos=0, prev_pos=0; static_cast<std::string::size_type>(pos) <= line.length(); pos++) {
       if (line[pos] == ',' || static_cast<std::string::size_type>(pos) == line.length()) {
         const auto field = line.substr(prev_pos, pos-prev_pos);
@@ -97,7 +97,7 @@ void load() {
     if (is_debug) std::cout << "line: " << line << " s: " << s << " e: " << e << " D: " << d << std::endl;
     // cerr << "line:" << line << "s:" << s << " e:" << e << " d:" << d << endl;
     // std::this_thread::sleep_for(std::chrono::seconds(1));
-    add_edge(s, e, (int)d);
+    add_edge(s, e, d);
   }
 }
 


### PR DESCRIPTION
C++がRustに負けたと聞いて

### 変更点

- ベースバージョンをC++17に変更
    - `std::string_view` 使いたかったので
    - GNU拡張も消しました．VLAはC++の機能ではない．
- コンパイラオプションを追加
    - できるだけ性能が出やすいように
- コンパイラをClangに変更
    - 近年のClangの最適化は凄まじいものがある
    - 実際今回もGCCより速かったし，RustがLLVMに乗っかるならC++も乗っかりたい
- 競プロ味を感じるコードを修正
    - グローバル変数は個人的には日頃全くと言っていいほど使いませんが，ひとまず放置しています
    - この変更，「個人の好み」ではなく明確に理由があって変更しているので以下に示します
        - `using namespace std;` ですが，これはADLによって想定と異なる関数が呼び出される危険性が非常に高く，「望んでADLさせたい場合」を除いて使うべきではないです(し，その場合も必要な関数だけ `using` すれば良い)．今回だと(最終的には別名関数 `stoi_unchecked` としましたが) 41b10e7ff3b06d39bb24bf95c399188193632bd9 のように「標準ライブラリの関数と同名の関数」を定義した時に意図せずこれが発生する(例えば自分の実装した `stoi` ではなく `std::stoi` が呼ばれてしまう)危険性があります(ADLの挙動を完全に理解していてそれでも `using namespace std;` したい，ということであればまぁご自由にしていただければと思います，完全理解者には敵わないので…)．
            - それはそれとして 3e5dfe941cc1755356583005f1454f79a2b5325c 時点で `stoi` の呼び出しに `std::` 付けてないのはミスです…
        - `#include<bits/stdc++.h>` ですが，これはlibstdc++の独自実装なので標準ライブラリを変更しにくくなります(移植性が悪い)．今回は(libc++環境用意するのが面倒だったので)コンパイラのみの変更に留めましたが，今後libstdc++以外の標準ライブラリ(libc++やMSの実装など)を使いたくなった時にそのままではコンパイルが通らなくなります．この点では上述のGNU拡張の排除も同様の理由です(MSVCで確実にコンパイルが通らない)
- `std::map` を `std::unordered_map` に変更
    - なんでC++だけ赤黒木なんですか…？
- 1行読むのに `std::getline` を使うように変更
- `std::string_view` 向けに `stoi` を再実装 (`stoi_unchecked`)
    - 入力として `int` 型に収まる整数以外は来ないことを前提に実装してある(`_unchecked` な)ので，ちゃんと整数かどうかを解析する `std::stoi` に比べて脆弱な実装ですが…
- `stof100` 関数の実装を高速化
- いくつかの関数をinline化
- あと無駄なコピーとかキャストを削減

### 実行結果

以下の環境で1回ずつ走らせました．

```console
$ uname -a
Linux HOSTNAME 4.15.0-72-generic #81-Ubuntu SMP Tue Nov 26 12:20:02 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
$ cat /etc/os-release
NAME="Ubuntu"
VERSION="18.04.3 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.3 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
$ cat /proc/cpuinfo | grep "model name"
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
model name      : AMD Ryzen 7 2700X Eight-Core Processor
$ clang++ --version
clang version 11.0.0 (http://github.com/llvm/llvm-project 3646ee503dfb8bd4e02294fc122a80b95900ca16)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /path/to
$ g++ --version
g++ (GCC) 11.0.0 20200622 (experimental)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ rustc --version
rustc 1.44.1 (c7087fe00 2020-06-17)
```

Rust(8763034970cc380b4ecd3f4ba6180f3c7d0d3e26):

```
  Time (mean ± σ):      1.451 s ±  0.008 s    [User: 1.435 s, System: 0.015 s]
  Range (min … max):    1.442 s …  1.462 s    10 runs
```

Rust(#6, 905642efaa80adbd0adca9d6cc930d0532566207):

```
  Time (mean ± σ):      1.429 s ±  0.010 s    [User: 1.410 s, System: 0.018 s]
  Range (min … max):    1.411 s …  1.440 s    10 runs
```

C++(8763034970cc380b4ecd3f4ba6180f3c7d0d3e26):

```
  Time (mean ± σ):      1.774 s ±  0.010 s    [User: 1.755 s, System: 0.018 s]
  Range (min … max):    1.755 s …  1.792 s    10 runs
```

C++(8b4338ff53cce85db56aff2ce12ce1e9b62f559c):

```
  Time (mean ± σ):      1.417 s ±  0.013 s    [User: 1.393 s, System: 0.023 s]
  Range (min … max):    1.407 s …  1.450 s    10 runs
```

Rustに勝ちました． ~~多分これが一番速いと思います~~