### PR TITLE
Speedup Rust program about 1%.

### DIFF
--- a/rust/.cargo/config
+++ b/rust/.cargo/config
@@ -1,0 +1,5 @@
+[build]
+target-dir = "target"
+rustflags = [
+    "-C", "target-cpu=native",
+]


### PR DESCRIPTION
Rust でコンパイル時に "-C target-cpu=native" を追加する事で 1% 程度高速化しました。
Makefile で追加する事も可能ですが、
rust/.cargo/config
の方が読み書きし易いと判断してこちらに追加しました。

ついでに、rust/.cargo/config の target-dir を "target" に設定しました。
target のパスが Makefile で決め打ちになっている為、
target-dir を "target" 以外に設定しているユーザーでエラーになる問題が修正されます。