### PR TITLE
Use reader.ReuseRecord

### DIFF
--- a/go/src/main.go
+++ b/go/src/main.go
@@ -79,6 +79,7 @@ func stof100(s string) int {
 
 func load() {
 	reader := csv.NewReader(os.Stdin)
+	reader.ReuseRecord = true
 	line, err := reader.Read() // skip header
 
 	for {


### PR DESCRIPTION
CSVレコードのメモリを再利用するとパフォーマンスが(微量ですが)向上します。