### PR TITLE
Fix bugs in dijkstra algorithm and csv parsing

### DIFF
--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -50,7 +50,7 @@ inline int stoi_unchecked(std::string_view s) {
 // 123.4567 --> 12345
 inline int stof100(std::string_view s) {
   int result = 0;
-  int place = 3;
+  int place = 2;
   auto it = s.cbegin();
   const auto end = s.cend();
   for(; it != end; ++it) {
@@ -61,11 +61,11 @@ inline int stof100(std::string_view s) {
     result *= 10;
     result += *it - '0';
   }
-  for(; it != end && place --> 0; ++it) {
+  for(; it != end && place-- > 0; ++it) {
     result *= 10;
     result += *it - '0';
   }
-  while(place --> 0) {
+  while(place-- > 0) {
     result *= 10;
   }
   return result;
@@ -80,10 +80,11 @@ void load() {
     if (std::cin.eof()) {
       break;
     }
+    while (!isgraph(line.back())) line.pop_back(); // strip
     NodeId s = 0, e = 0;
     Distance d = 0;
     for (std::string::size_type idx=0, pos=0, prev_pos=0; pos <= line.length(); pos++) {
-      if (line[pos] == ',' || pos == line.length()) {
+      if (line[pos] == ',' || line[pos] == '\r' || pos == line.length()) {
         const auto field = std::string_view{line}.substr(prev_pos, pos-prev_pos);
         switch (idx) {
           case 2: s = stoi_unchecked(field); break;
@@ -109,6 +110,7 @@ inline std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId en
 
   const int size = g.idx;
   std::vector<Distance> d(size);
+  std::fill(d.begin(),d.end(),INT32_MAX);
   std::vector<NodeIndex> prev(size);
 
   std::priority_queue<Visit, std::vector<Visit>, std::greater<Visit>> queue;
@@ -120,12 +122,14 @@ inline std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId en
     queue.pop();
     const Distance distance = a.first;
     const NodeIndex here = a.second;
+    if (distance > d[here]) continue;
     if (is_debug) std::cout << "visiting: " << here << " distance: " << distance << std::endl;
     visited++;
+
     for (const Edge& e : g.edge[here]) {
       const NodeIndex to = e.first;
       const Distance w = distance + e.second;
-      if (d[to] == 0 || w < d[to]) {
+      if (w < d[to]) {
         prev[to] = here;
         d[to] = w;
         queue.push({w, to});
@@ -139,7 +143,7 @@ inline std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId en
   NodeIndex n = e;
   result.push_back(g.idx2id[n]);
 
-  while (d[n] != 0 && n != s && n != 0) {
+  while (d[n] != INT32_MAX && n != s && n != 0) {
     n = prev[n];
     result.push_back(g.idx2id[n]);
   }

--- a/javascript/src/main.js
+++ b/javascript/src/main.js
@@ -36,24 +36,25 @@ function add_edge(start, end, distance) {
 
 function stof100(s) {
 	let result = 0;
-	let place = 0;
+	let place = 2;
+	let is_decimal_place = false;
 	for (const ch of s) {
 	  if (ch == '.') {
-		place = 1;
+		is_decimal_place = true;
 		continue;
 	  }
 	  result *= 10;
 	  result += ch - '0';
-	  if (place > 0) {
-		place++;
-		if (place >= 3) {
+	  if (is_decimal_place) {
+		place--;
+		if (place == 0) {
 			break;
 		}
 	  }
 	}
-	while (place < 3) {
+	while (place > 0) {
 	  result *= 10;
-	  place++;
+	  place--;
 	}
 	return result;
 }
@@ -78,8 +79,9 @@ function dijkstra(start , end ) {
 	const s = get_idx(start);
 	const e = get_idx(end);
 
+	const MAX_INT32 = 2147483647; // 2^31-1 - this is not the max value of javascript Number but good for this benchmark
 	const size = g.idx;
-	const d = new Array(size+1).fill(0);
+	const d = new Array(size+1).fill(MAX_INT32); 
 	const prev = new Array(size+1).fill(0);
 
 	const queue = new pq();
@@ -88,12 +90,13 @@ function dijkstra(start , end ) {
 	let visited = 0;
 	while (!queue.Empty()) {
 		const [distance, here] = queue.Pop();
+		if (distance > d[here]) continue;
 		visited++;;
 		if (is_debug) console.log("visiting:", here, "distance:", distance);
 		for (let e of g.edge[here]) {
 			const to = e[0];
 			const w = distance + e[1];
-			if (d[to] === 0 || w < d[to]) {
+			if (w < d[to]) {
 				prev[to] = here;
 				d[to] = w;
 				queue.Push([w, to]);
@@ -105,7 +108,7 @@ function dijkstra(start , end ) {
 	let n = e;
 	let result = [n];
 
-	while (d[n] !== 0 && n !== s && n !== 0) {
+	while (d[n] !== MAX_INT32 && n !== s && n !== 0) {
 		n = prev[n];
 		result.push(g.idx2id[n]);
 	}

--- a/julia/src/priorityqueue.jl
+++ b/julia/src/priorityqueue.jl
@@ -2,7 +2,7 @@ import Base.pop!
 
 const NodeId = UInt32
 const NodeIndex = UInt32
-const Distance = UInt32
+const Distance = Int32
 
 struct Visit
 	first::Distance

--- a/kotlin/src/main/kotlin/main/main.kt
+++ b/kotlin/src/main/kotlin/main/main.kt
@@ -38,24 +38,25 @@ fun add_edge(start:NodeId, end:NodeId, distance:Distance) {
 
 fun stof100(s:String):Int {
 	var result = 0
-	var place = 0
+	var place = 2
+	var is_decimal_place = false
 	for (ch in s) {
 		if (ch == '.') {
-			place = 1
+			is_decimal_place = true
 			continue
 		}
 		result *= 10
 		result += ch - '0'
-		if (place > 0) {
-			place++
-			if (place >= 3) {
+		if (is_decimal_place) {
+			place--
+			if (place == 0) {
 				break;
 			}
 		}
 	}
-	while (place < 3) {
+	while (place > 0) {
 		result *= 10
-		place++
+		place--
 	}
 	return result;
 }
@@ -85,7 +86,7 @@ fun dijkstra(start:NodeId, end:NodeId):Result {
 	val e = get_idx(end)
 
 	val size = g.idx
-	val d = Array<Distance>(size) { 0 }
+	val d = Array<Distance>(size) { Int.MAX_VALUE }
 	val prev = Array<NodeIndex>(size) { 0 }
 
 	val queue = PriorityQueue()
@@ -94,12 +95,15 @@ fun dijkstra(start:NodeId, end:NodeId):Result {
 	var visited = 0
 	while (!queue.empty()) {
 		val (distance, here) = queue.pop()
+		if (distance > d[here]) {
+			continue
+		}
 		visited++
 		if (is_debug) println("visiting: " + here + " distance: " + distance)
 
 		for ((to, weight) in g.edge[here]) {
 			val w = distance + weight
-			if (d[to] == 0 || w < d[to]) {
+			if (w < d[to]) {
 				prev[to] = here
 				d[to] = w
 				queue.push(Visit(w, to))
@@ -111,7 +115,7 @@ fun dijkstra(start:NodeId, end:NodeId):Result {
 	var n = e
 	val result = mutableListOf(g.idx2id[n])
 
-	while (d[n] != 0 && n != s && n != 0) {
+	while (d[n] != Int.MAX_VALUE && n != s && n != 0) {
 		n = prev[n]
 		result.add(g.idx2id[n])
 	}

--- a/python/src/main.py
+++ b/python/src/main.py
@@ -33,20 +33,21 @@ def add_edge(start, end, distance):
 # .5 -> 50
 def stof100(s):
 	result = 0
-	place = 0
+	place = 2
+	is_decimal_place = False
 	for ch in s:
 		if ch == '.':
-			place = 1
+			is_decimal_place = True
 			continue
 		result *= 10
 		result += ord(ch) - ord('0')
-		if  place > 0:
-			place += 1
-			if place >= 3:
+		if is_decimal_place:
+			place -= 1
+			if place == 0:
 				break
-	while place < 3:
+	while place > 0:
 		result *= 10
-		place += 1
+		place -= 1
 	return result
 
 
@@ -67,8 +68,9 @@ def dijkstra(start, end):
 	s = get_idx(start)
 	e = get_idx(end)
 
+	MAX_INT32 = 2147483647 # 2^31-1 - this is not the max value of python Number but good for this benchmark
 	size = g.idx
-	d = [0] * size
+	d = [MAX_INT32] * size
 	prev = [0] * size
 
 	queue = []
@@ -77,12 +79,14 @@ def dijkstra(start, end):
 	visited = 0
 	while len(queue) > 0:
 		distance, here = heappop(queue)
-		visited = visited + 1
+		if distance > d[here]:
+			continue
+		visited += 1
 		if is_debug:
 			print(f"visiting: {here} distance: {distance}")
 		for to, weight in g.edge[here]:
 			w = distance + weight
-			if d[to] == 0 or w < d[to]:
+			if w < d[to]:
 				prev[to] = here
 				d[to] = w
 				heappush(queue, (w, to))
@@ -91,7 +95,7 @@ def dijkstra(start, end):
 	n = e
 	result = [g.idx2id[n]]
 
-	while d[n] != 0 and n != s and n != 0:
+	while d[n] != MAX_INT32 and n != s and n != 0:
 		n = prev[n]
 		result.append(g.idx2id[n])
 


### PR DESCRIPTION
Fixes three bugs and one refactoring

1. Dijkstra loop should check if the popped (from priority queue) distance for node `i` is smaller than calculated distance `d[i]`. This r reduces the complexity of main the loopto O( (|V|+|E| log |V|) - don't know the original's complexity  - Thanks [TsumoiYorozu](https://qiita.com/TumoiYorozu) !

2. Fill distance array `d` in Dijkstra loop with enough big value like `INT32_MAX`  to reduce `d[i] == 0` (checks if the node has been already visited)

3. CSV parsing logic has a critical bug - parses integer without decimal dot to x1000 instead of x100.

4. Use `Int32` for `Distance` type explicitly. But still not completed over all languages in this benchmark.