### PR TITLE
C++実装のリファクタリング/高速化(again)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cpp/external_projects/robin-hood-hashing"]
+	path = cpp/external_projects/robin-hood-hashing
+	url = https://github.com/martinus/robin-hood-hashing

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Simple benchmarks of Dijkstra algorithm among C++, Go, Julia, Python(+Cython), J
 
 # Requirement
 
+Submodules are contained.
+You need to `git submodule update --init --recursive` at first.
+
 This benchmark uses [hyperfine](https://github.com/sharkdp/hyperfine).
 
 And runs on languages below:

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -4,4 +4,4 @@ clean:
 	rm main
 
 main: src/main.cpp
-	clang++ -std=c++17 -O3 -Wall -Wextra -pedantic-errors -march=native -mtune=native -o main src/main.cpp
+	clang++ -std=c++17 -O3 -Wall -Wextra -pedantic-errors -march=native -mtune=native -I external_projects/robin-hood-hashing/src/include -o main src/main.cpp

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -86,7 +86,7 @@ void load() {
     NodeId s, e;
     Distance d;
     for (std::string::size_type idx=0, pos=0, prev_pos=0; pos <= line.length(); pos++) {
-      if (line[pos] == ',' || line[pos] == '\r' || pos == line.length()) {
+      if (line[pos] == ',' || pos == line.length()) {
         const auto field = std::string_view{line}.substr(prev_pos, pos-prev_pos);
         switch (idx) {
           case 2: s = stoi_unchecked(field); break;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -6,6 +6,7 @@
 #include<queue>
 #include<cstdint>
 #include<limits>
+#include"robin_hood.h"
 
 using NodeId = int;
 using NodeIndex = int;
@@ -17,7 +18,7 @@ constexpr int DISTANCE_MULTIPLE = 100;
 bool is_debug = false;
 
 struct G {
-  std::unordered_map<NodeId,NodeIndex> id2idx;
+  robin_hood::unordered_map<NodeId,NodeIndex> id2idx;
   std::vector<NodeId> idx2id = {0};
   NodeIndex idx = 1;
   std::vector<std::vector<Edge>> edge = {std::vector<Edge>()};

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -110,8 +110,7 @@ inline std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId en
   const NodeIndex e = get_idx(end);
 
   const int size = g.idx;
-  std::vector<Distance> d(size);
-  std::fill(d.begin(),d.end(),INT32_MAX);
+  std::vector<Distance> d(size, INT32_MAX);
   std::vector<NodeIndex> prev(size);
 
   std::priority_queue<Visit, std::vector<Visit>, std::greater<Visit>> queue;

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -5,6 +5,7 @@
 #include<iostream>
 #include<queue>
 #include<cstdint>
+#include<limits>
 
 using NodeId = int;
 using NodeIndex = int;
@@ -110,7 +111,7 @@ inline std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId en
   const NodeIndex e = get_idx(end);
 
   const int size = g.idx;
-  std::vector<Distance> d(size, INT32_MAX);
+  std::vector<Distance> d(size, std::numeric_limits<Distance>::max());
   std::vector<NodeIndex> prev(size);
 
   std::priority_queue<Visit, std::vector<Visit>, std::greater<Visit>> queue;
@@ -143,7 +144,7 @@ inline std::pair<Distance, std::vector<NodeId>> dijkstra(NodeId start, NodeId en
   NodeIndex n = e;
   result.push_back(g.idx2id[n]);
 
-  while (d[n] != INT32_MAX && n != s && n != 0) {
+  while (d[n] != std::numeric_limits<Distance>::max() && n != s && n != 0) {
     n = prev[n];
     result.push_back(g.idx2id[n]);
   }

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -83,8 +83,8 @@ void load() {
       break;
     }
     while (!isgraph(line.back())) line.pop_back(); // strip
-    NodeId s = 0, e = 0;
-    Distance d = 0;
+    NodeId s, e;
+    Distance d;
     for (std::string::size_type idx=0, pos=0, prev_pos=0; pos <= line.length(); pos++) {
       if (line[pos] == ',' || line[pos] == '\r' || pos == line.length()) {
         const auto field = std::string_view{line}.substr(prev_pos, pos-prev_pos);

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -4,10 +4,11 @@
 #include<string_view>
 #include<iostream>
 #include<queue>
+#include<cstdint>
 
 using NodeId = int;
 using NodeIndex = int;
-using Distance = int;
+using Distance = std::int32_t;
 using Edge = std::pair<NodeIndex, Distance>;
 
 constexpr int DISTANCE_MULTIPLE = 100;


### PR DESCRIPTION
レギュレーションの変更(ダイクストラ法の修正)に伴ってRustより遅くなったので

### 変更点

- リファクタリング
    - `Distance` を `std::int32_t` に
    - `INT32_MAX` を `std::numeric_limits<Distance>::max()` に
        - 将来 `Distance` を `std::int64_t` にすることがあっても勝手に `INT64_MAX` を引いてくれます． ~~そんな変更する予定一切無いでしょうが…~~
    - `std::vector` のfillをコンストラクタで行うように変更
- 高速化
    - 変数の初期化を除去
        - 想定する入力が来ると仮定して良い場合，初期化しても上書きされるので不要です
    - `line[pos] == '\r'` の条件式を削除
        - 直前の `while (!isgraph(line.back())) line.pop_back();` で行末の `'\r'` は除去されているため，この条件式が `true` になるのは行の途中に出てきたときだけです(そしてそのような入力は想定していないと思います)
    - ハッシュマップの実装を `robin-hood-hashing` に変更
        - @mitsutaka-takeda さんのアイデアを反映(https://github.com/mitsutaka-takeda/langs-bench-dijkstra)
        - Rustも標準ライブラリ外のハッシュ実装を使っているので，C++も使って良いのではないかと思います．
        - git submoduleを使うようにしたので，READMEに「`git submodule update --init` 忘れないでね」の文言を追加

### 実行結果

実行環境は #4 と同様です．

Rust(10b505d10d838eb3f10efafc6b232e5da1bd1921):

```
  Time (mean ± σ):      1.439 s ±  0.008 s    [User: 1.424 s, System: 0.014 s]
  Range (min … max):    1.424 s …  1.448 s    10 runs
```

C++(10b505d10d838eb3f10efafc6b232e5da1bd1921):

```
  Time (mean ± σ):      1.543 s ±  0.007 s    [User: 1.525 s, System: 0.017 s]
  Range (min … max):    1.535 s …  1.555 s    10 runs
```

C++(4f9c518f4c598e548fb1af3f9e2d3f9bc9002bb7):

```
  Time (mean ± σ):      1.343 s ±  0.007 s    [User: 1.322 s, System: 0.021 s]
  Range (min … max):    1.332 s …  1.355 s    10 runs
```

Rustに勝ちました． ~~多分これが一番速いと思います~~