### PR TITLE
Fix `test.sh` to print error message when language command failed

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e    # exit when command failed
+set -u    # exit when non-initalized variable found
+
 function check {
   local lang=$1
   echo "Testing $lang..."
@@ -9,8 +12,6 @@ function check {
   popd > /dev/null
   diff -u out/expected.txt out/$lang.txt | head
 }
-
-set -e
 
 if [ -n "$1" ]; then
   for lang in "$@"; do

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ function check {
   echo "Testing $lang..."
   pushd $lang > /dev/null
   make -i clean > /dev/null && make > /dev/null
-  ./bench.sh 1 debug < ../data/Tokyo_Edgelist.csv > ../out/$lang.txt 2>&1
+  ./bench.sh 1 debug < ../data/Tokyo_Edgelist.csv > ../out/$lang.txt
   popd > /dev/null
   diff -u out/expected.txt out/$lang.txt | head
 }

--- a/test.sh
+++ b/test.sh
@@ -17,7 +17,7 @@ if [ -n "$1" ]; then
   for lang in "$@"; do
     check $lang
   done
-else 
+else
   for lang in cpp go rust javascript julia kotlin python cython pypy; do
     check $lang
   done


### PR DESCRIPTION
before: (nothing reported even when command failed)
```
$ bash test.sh python
Testing python...
make: *** No rule to make target `clean'.  Stop.
```

after: (error message printed!!)
```
$ bash test.sh python
Testing python...
make: *** No rule to make target `clean'.  Stop.
  File "src/main.py", line 51
    return result
                ^
TabError: inconsistent use of tabs and spaces in indentation
```
